### PR TITLE
Parallel replay train

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ The solution I will transition to after that is DQN (Deep Q-Learning), which I h
 -- Look into Stochastic Weight Averaging (SWA), including possibly creating a learning schedule that involves starting the averaging/sharing learning at a certain point after enough training has occurred in each individual agent.
 -- Or value higher performing model's weights over lower performing ones.
 - Add screen to watch the current model training.
+- Maybe scale the max turn length with the current episode number?

--- a/README.md
+++ b/README.md
@@ -18,3 +18,5 @@ The solution I will transition to after that is DQN (Deep Q-Learning), which I h
 # To improve
 - Maybe train multiple models at once, then average the model's weights occasionally. This avoids having to do extreme parallelizing, since I am struggling to implement that, but it would allow us to speed up the process.
 -- Look into Stochastic Weight Averaging (SWA), including possibly creating a learning schedule that involves starting the averaging/sharing learning at a certain point after enough training has occurred in each individual agent.
+-- Or value higher performing model's weights over lower performing ones.
+- Add screen to watch the current model training.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,5 @@ So, its not optimal, but I am going to be choosing NEAT for this solution, as th
 The solution I will transition to after that is DQN (Deep Q-Learning), which I have heard is very good at this sort of thing, and has a good primer on most of the key aspects of manual AI training, with back propagation and replay training.
 
 # To improve
-- reduce fitness points for every turn that the board does not change
-- Don't record gamestates where nothing changed, to save on gamestate space. Will have to update fitness penalty to track this new system.
-- Utilize Q Deep learning
+- Maybe train multiple models at once, then average the model's weights occasionally. This avoids having to do extreme parallelizing, since I am struggling to implement that, but it would allow us to speed up the process.
+-- Look into Stochastic Weight Averaging (SWA), including possibly creating a learning schedule that involves starting the averaging/sharing learning at a certain point after enough training has occurred in each individual agent.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ So, its not optimal, but I am going to be choosing NEAT for this solution, as th
 The solution I will transition to after that is DQN (Deep Q-Learning), which I have heard is very good at this sort of thing, and has a good primer on most of the key aspects of manual AI training, with back propagation and replay training.
 
 # To improve
+- Make it so the script automatically identifies and uses the right existing weights when resuming training, without manual input.
 - Maybe train multiple models at once, then average the model's weights occasionally. This avoids having to do extreme parallelizing, since I am struggling to implement that, but it would allow us to speed up the process.
 -- Look into Stochastic Weight Averaging (SWA), including possibly creating a learning schedule that involves starting the averaging/sharing learning at a certain point after enough training has occurred in each individual agent.
 -- Or value higher performing model's weights over lower performing ones.

--- a/algorithms/dqn.py
+++ b/algorithms/dqn.py
@@ -252,7 +252,7 @@ class DQNTrainer():
                         raise Exception("Exit signal received while replay training")
         ############ END - Protections #############
         
-        with terminating_executor(max_workers=dqns.MAX_WORKERS) as executor:
+        with terminating_executor(max_workers=dqns.REPLAY_TRAIN_WORKERS) as executor:
             for replay in minibatch:
                 executor.submit(train_one, replay)
 

--- a/algorithms/dqn.py
+++ b/algorithms/dqn.py
@@ -41,9 +41,6 @@ class MemoryBuffer():
     # This prevents unnecessary disk writes on potentially very large files, since we are
     # going to have up to 2000 records in our replay buffer.
     unsaved_changes: bool
-    # We cannot store native object inside the pickle object.
-    # Having this here, because on linux we cannot store the object natively.
-    can_store_as_object: bool = False
 
     def __init__(self, len=2000, mem_file_name = "memory.pickle", reset = False):
         print(f"What is this file name {mem_file_name}")

--- a/config/settings.py
+++ b/config/settings.py
@@ -77,7 +77,11 @@ class DQNSettings:
     EPSILON_MIN = 0.01    # Final exploration rate
     # Started at 0.995
     EPSILON_DECAY = 0.995  # Decay rate per generation
-
+    
+    # There is a tighter limit on the value of more workers for this, since we have
+    # required locks necessary to maintain functionality. So at some point, adding more
+    # workers will not yield faster performance
+    MAX_WORKERS = 2
     REPLAY_BUFFER_SIZE = 2000   # Total number of replays to keep in memory
     REPLAY_BATCH_SIZE = 64      # Number of replays to sample when making decision
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -81,7 +81,7 @@ class DQNSettings:
     # There is a tighter limit on the value of more workers for this, since we have
     # required locks necessary to maintain functionality. So at some point, adding more
     # workers will not yield faster performance
-    MAX_WORKERS = 2
+    REPLAY_TRAIN_WORKERS = 2
     REPLAY_BUFFER_SIZE = 2000   # Total number of replays to keep in memory
     REPLAY_BATCH_SIZE = 64      # Number of replays to sample when making decision
 


### PR DESCRIPTION
So, I am really trying my best to speed this up, as our current projection for 10,000 training iterations is about 500 days. Which is insane.

I don't expect this to be an insane improvement, but I am hoping it helps a decent amount.

I will be running tests to figure out the sweet spot for the number of workers to use for this, since this is different than normal, where throwing more workers increases speed. There is a number of workers that will maximize the value of this, since there are locks to prevent 