### PR TITLE
Add support for increasing turn limits

### DIFF
--- a/algorithms/dqn.py
+++ b/algorithms/dqn.py
@@ -247,7 +247,11 @@ class DQNTrainer():
                     self.reset()
                     game_states = DQNStates(episode)
                     # TODO: Enable viewing somehow when display is not disabled.
-                    for i in range(max_time):  # Arbitrary max time steps per episode
+                    i = 0
+                    while True:
+                        if max_time and i >= max_time:
+                            break
+                        i += 1
                         game_states.store(self.board)
                         action = self._choose_action()
                         # print(f"Our action results are type {type(action)}, and heres its value {action}")
@@ -276,7 +280,7 @@ class DQNTrainer():
                             if self.epsilon > self.epsilon_min:
                                 self.epsilon *= self.epsilon_decay
 
-                    if i == max_time:
+                    if i >= max_time:
                         game_states.add_notes("We stalled our game out too long.")
                 finally: # After training one episode
                     game_states.log_game()

--- a/algorithms/dqn.py
+++ b/algorithms/dqn.py
@@ -293,7 +293,7 @@ class DQNTrainer():
                     # Actually, we are going to do it one less, because we want to be able to catch up in case the
                     # games are going longer due to fitter populations learning to survive.
                     if (episode % (BATCH_REMOVE_GENS - 1)) == 0:
-                        prune_gamestates()
+                        prune_gamestates(dqn=True)
         finally: # After trying whole training loop
             # Make sure to close our replay buffer to ensure it works properly.
             self.replay_buffer.close()

--- a/analyze_dqn.py
+++ b/analyze_dqn.py
@@ -4,6 +4,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
+from config.settings import DQNSettings
+
 # Directory containing the JSON files
 directory = 'game_states'
 
@@ -32,7 +34,8 @@ for filename in os.listdir(directory):
             score_values.append(data['score'])
             populations.append(population)
             # Check if the game timed out
-            timeouts.append(len(data['game_states']) == 1000)
+            timed_out = len(data['game_states']) >= DQNSettings.MAX_TURNS if DQNSettings.MAX_TURNS else False
+            timeouts.append(timed_out)
 
 # Convert lists to pandas DataFrame for easier manipulation
 df = pd.DataFrame({

--- a/files/manage_files.py
+++ b/files/manage_files.py
@@ -93,7 +93,7 @@ def clean_gamestates(dqn = False):
                 # We are training dqn
                 nums[int(name[name.find("_") + 1:-5])] = name
         return nums
-    gen_map: dict[int, str] = get_gen_nums(existing_gens)
+    gen_map: dict[int, str] = get_gen_nums(existing_gens, dqn)
     gen_nums = list(gen_map.keys())
     gen_nums.sort()
     p(f"We have {len(gen_nums)} available gen nums before")
@@ -142,6 +142,7 @@ def clean_gamestates(dqn = False):
     for num in gen_nums:
         # Remove the oldest generations first
         path = f"{GAMESTATES_PATH}/{gen_map[num]}"
+        p(f"Removing protected generation {num}")
         try:
             delete_object(path)
             removed += 1
@@ -157,7 +158,9 @@ def prune_gamestates(dqn = False):
     Maybe try to be cheeky and return a guess for how many generations to wait before checking again.
     """
     size = GetFolderSize(GAMESTATES_PATH)
-    if (size > MAX_SIZE_OF_GAMESTATES * (1024 * 1024 * 1024)):
+    max_size_gb = MAX_SIZE_OF_GAMESTATES * (1024 * 1024 * 1024)
+    p(f"Checking if our current game states exceed maximum allowed amount. {size} > {max_size_gb}")
+    if (size > max_size_gb):
         clean_gamestates(dqn)
 
 #### END MANAGE GAME STATES ####

--- a/files/manage_files.py
+++ b/files/manage_files.py
@@ -43,8 +43,18 @@ def delete_folder(folder):
             print('Failed to delete %s. Reason: %s' % (file_path, e))
     pathlib.Path.rmdir(folder)
 
+def delete_object(obj_path: str):
+    """Delete either a folder or file.
 
-def clean_gamestates():
+    Args:
+        path (str): path to object
+    """
+    if os.path.isfile(obj_path) or os.path.islink(obj_path):
+        os.unlink(obj_path)
+    elif os.path.isdir(obj_path):
+        delete_folder(obj_path)
+
+def clean_gamestates(dqn = False):
     """Cleans out gamestates.
 
     Will delete the oldest $BATCH_REMOVE_GENS from gamestates, perserving every
@@ -63,12 +73,35 @@ def clean_gamestates():
     # We know for a fact that we have to remove some generations.
     # Get all generations
     existing_gens = os.listdir(GAMESTATES_PATH)
-    gen_nums = [int(name[4:]) for name in existing_gens]
-    p(f"We have {len(gen_nums)} available gen nums before")
+    def get_gen_nums(gen_files: list[str], dqn = False) -> dict[int, str]:
+        """Get generation numbers of gamestates to purge.
+
+        Args:
+            gen_files (list[str]): Names of all the generation files
+            dqn (bool, optional): Whether we are training dqn or not. Defaults to False.
+
+        Returns:
+            dict[int, str]: dictionary of the generation numbers present mapping 
+                            to their respective file names.
+        """
+        nums: dict[int] = {}
+        for name in gen_files:
+            if not dqn:
+                # We are training neat
+                nums[int(name[4:])] = name
+            else:
+                # We are training dqn
+                nums[int(name[name.find("_") + 1:-5])] = name
+        return nums
+    gen_map: dict[int, str] = get_gen_nums(existing_gens)
+    gen_nums = list(gen_map.keys())
     gen_nums.sort()
+    p(f"We have {len(gen_nums)} available gen nums before")
 
     removed = 0
     # Delete $BATCH_REMOVE_GENS, while perserving archived generations
+    # gen_nums[:] to create a copy so we can modify list. This list can be used later if we do not find enough
+    # non-protected generations to delete and have to resort to destroying them
     for num in gen_nums[:]:
         # Check if we should keep this one archived
         if ARCHIVE_GEN_INTERVAL and (num % ARCHIVE_GEN_INTERVAL) == 0:
@@ -76,11 +109,23 @@ def clean_gamestates():
             continue
         # delete this generation
         p(f"Deleting generation {num}")
-        delete_folder(f"{GAMESTATES_PATH}/gen_{num}")
+        file_path = f"{GAMESTATES_PATH}/{gen_map[num]}"
+        try:
+            delete_object(file_path)
+        except:
+            msg = "ERROR: We failed to delete a DQN gamestate file, despite it being marked for removal. Something is wrong"
+            p(msg)
+            raise
+
         # Housekeeping
         # Remove from original list incase we need to 
         # start removing protected generations
-        gen_nums.remove(num)
+        try:
+            del gen_map[num]
+            gen_nums.remove(num) # Remove from list too incase we need to use list later for destroying protected gens
+        except KeyError:
+            print("ERROR: Somehow we deleted the file, but it wasn't present in the dictionary anymore. Something is really wrong.")
+            raise
         removed += 1
         if removed >= BATCH_REMOVE_GENS:
             # We removed enough.
@@ -94,20 +139,26 @@ def clean_gamestates():
         p("We couldn't remove enough generations, we are getting rid of protected generations now")
     
     # We did not remove enough. Start removing the protected generations
-    for i in range(BATCH_REMOVE_GENS - removed):
+    for num in gen_nums:
         # Remove the oldest generations first
-        delete_folder(f"{GAMESTATES_PATH}/gen_{gen_nums[i]}")
+        path = f"{GAMESTATES_PATH}/{gen_map[num]}"
+        try:
+            delete_object(path)
+            removed += 1
+            if removed >= BATCH_REMOVE_GENS:
+                # We removed enough.
+                return
+        except:
+            p(f"Failed to delete object {path}, i dont care much anymore, just move on to the next one.")
 
-    pass
-
-def prune_gamestates():
+def prune_gamestates(dqn = False):
     """Will check if the gamestates folder is too full, then clean it up if it is
 
     Maybe try to be cheeky and return a guess for how many generations to wait before checking again.
     """
     size = GetFolderSize(GAMESTATES_PATH)
     if (size > MAX_SIZE_OF_GAMESTATES * (1024 * 1024 * 1024)):
-        clean_gamestates()
+        clean_gamestates(dqn)
 
 #### END MANAGE GAME STATES ####
 


### PR DESCRIPTION
In accordance with this issue: https://github.com/Baylus/2048I/issues/17
I am suspecting that there might be a negative relationship between the imposed turn limit and the model's learning rate, or general capability. Because of this, I am going to attempt to train without any turn limit and see if that has any positive relationship with learning/performance.

I will be adjusting the interval that we automatically save our checkpoints because the episodes will likely be much longer than before. I also have to double check that the automatic game state culling is functional for the DQN training, to ensure that I don't fill my entire D drive.